### PR TITLE
[ASSIGNMENT] 6차 과제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -41,10 +41,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (IllegalArgumentException | JWTVerificationException e) {
-                // 유효하지 않은 토큰 또는 토큰이 없는 경우, 인증 없이 다음 필터로 넘겨요.
-                // 여기서 예외를 던지지 않는 이유는, /v1/login 같이 인증이 필요 없는 API도
-                // 이 필터를 거치기 때문이에요. 인증 여부 판단은 SecurityConfig의
-                // authorizeHttpRequests 설정에서 담당합니다.
+                SecurityContextHolder.clearContext();
             }
         }
 

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -1,10 +1,10 @@
 package org.sopt.config;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.sopt.exception.CustomException;
 import org.sopt.service.JwtService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -40,7 +40,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                         String.valueOf(userId), null, Collections.emptyList());
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
-            } catch (IllegalArgumentException | JWTVerificationException e) {
+            } catch (CustomException e) {
                 SecurityContextHolder.clearContext();
             }
         }

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -35,9 +35,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring("Bearer ".length()).trim();
             try {
-                Long memberId = jwtService.verifyAndGetMemberId(token);
+                Long userId = jwtService.verifyAndGetUserId(token);
                 UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                        String.valueOf(memberId), null, Collections.emptyList());
+                        String.valueOf(userId), null, Collections.emptyList());
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (IllegalArgumentException | JWTVerificationException e) {

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.sopt.exception.CustomException;
 import org.sopt.service.JwtService;
 import org.springframework.http.HttpHeaders;
@@ -17,13 +18,10 @@ import java.io.IOException;
 import java.util.Collections;
 
 @Component
+@RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
-
-    public JwtAuthFilter(JwtService jwtService) {
-        this.jwtService = jwtService;
-    }
 
     @Override
     protected void doFilterInternal(

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.sopt.exception.CustomException;
+import org.sopt.repository.BlacklistedAccessTokenRepository;
 import org.sopt.service.JwtService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -22,6 +23,7 @@ import java.util.Collections;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
+    private final BlacklistedAccessTokenRepository blacklistedAccessTokenRepository;
 
     @Override
     protected void doFilterInternal(
@@ -33,6 +35,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring("Bearer ".length()).trim();
             try {
+                if (blacklistedAccessTokenRepository.existsByToken(token)) {
+                    SecurityContextHolder.clearContext();
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 Long userId = jwtService.verifyAndGetUserId(token);
                 UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                         String.valueOf(userId), null, Collections.emptyList());

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/users").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers(HttpMethod.GET, "/posts", "/posts/search", "/posts/*").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -36,9 +36,9 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/users").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/posts", "/posts/search", "/posts/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts", "/api/v1/posts/search", "/api/v1/posts/*").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception.authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -1,7 +1,12 @@
 package org.sopt.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.sopt.dto.response.BaseResponse;
+import org.sopt.exception.AuthErrorCode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,21 +21,40 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
+    private final ObjectMapper objectMapper;
 
-    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter, ObjectMapper objectMapper) {
         this.jwtAuthFilter = jwtAuthFilter;
+        this.objectMapper = objectMapper;
     }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v1/login", "/v1/reissue").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers(HttpMethod.POST, "/posts").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/posts/*").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/posts/*").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/posts/*/likes").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/posts/*/likes").authenticated()
+                        .requestMatchers("/api/v1/auth/me").authenticated()
+                        .anyRequest().permitAll()
                 )
+                .exceptionHandling(exception -> exception.authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(AuthErrorCode.UNAUTHENTICATED.getHttpStatus().value());
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    response.setCharacterEncoding("UTF-8");
+                    objectMapper.writeValue(response.getWriter(), BaseResponse.error(
+                            AuthErrorCode.UNAUTHENTICATED.getCode(),
+                            AuthErrorCode.UNAUTHENTICATED.getMessage()
+                    ));
+                }))
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -38,13 +38,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/posts").authenticated()
-                        .requestMatchers(HttpMethod.PUT, "/posts/*").authenticated()
-                        .requestMatchers(HttpMethod.DELETE, "/posts/*").authenticated()
-                        .requestMatchers(HttpMethod.POST, "/posts/*/likes").authenticated()
-                        .requestMatchers(HttpMethod.DELETE, "/posts/*/likes").authenticated()
-                        .requestMatchers("/api/v1/auth/me").authenticated()
-                        .anyRequest().permitAll()
+                        .requestMatchers(HttpMethod.GET, "/posts", "/posts/search", "/posts/*").permitAll()
+                        .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception.authenticationEntryPoint((request, response, authException) -> {
                     response.setStatus(AuthErrorCode.UNAUTHENTICATED.getHttpStatus().value());

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.sopt.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.sopt.dto.response.BaseResponse;
 import org.sopt.exception.AuthErrorCode;
 import org.springframework.context.annotation.Bean;
@@ -20,15 +21,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
     private final ObjectMapper objectMapper;
-
-    public SecurityConfig(JwtAuthFilter jwtAuthFilter, ObjectMapper objectMapper) {
-        this.jwtAuthFilter = jwtAuthFilter;
-        this.objectMapper = objectMapper;
-    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -53,5 +55,10 @@ public class SecurityConfig {
                 }))
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/org/sopt/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/config/SwaggerConfig.java
@@ -1,18 +1,28 @@
 package org.sopt.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
 
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(new Info().title("Swagger API").version("v1"))
-                .addServersItem(new Server().url("/"));
+                .addServersItem(new Server().url("/"))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
     }
 }

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -26,14 +26,19 @@ public class AuthController {
             @RequestParam("password") String password
     ) {
         TokenResponse tokens = authService.login(email, password);
-
-        // 토큰 쿠키에 저장
-
         return ResponseEntity.ok(BaseResponse.success(tokens));
     }
 
+    @Operation(summary = "토큰 재발급 (Refresh Token 검증)")
+    @PostMapping("/reissue")
+    public ResponseEntity<BaseResponse<TokenResponse>> reissue(
+            @RequestParam("refreshToken") String refreshToken
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(authService.reissue(refreshToken)));
+    }
+
     @Operation(summary = "내 정보 조회 (Access Token 검증)")
-    @GetMapping("/api/v1/me")
+    @GetMapping("/me")
     public ResponseEntity<BaseResponse<UserResponse>> me(Authentication authentication) {
 
         if (authentication == null || authentication.getPrincipal() == null) {

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -20,7 +20,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "로그인 (Access Token + Refresh Token 발급)")
+    @Operation(summary = "로그인")
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<TokenResponse>> login(
             @RequestParam("email") String email,
@@ -30,7 +30,7 @@ public class AuthController {
         return ResponseEntity.ok(BaseResponse.success(tokens));
     }
 
-    @Operation(summary = "토큰 재발급 (Refresh Token 검증)")
+    @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
     public ResponseEntity<BaseResponse<TokenResponse>> reissue(
             @RequestParam("refreshToken") String refreshToken
@@ -38,7 +38,7 @@ public class AuthController {
         return ResponseEntity.ok(BaseResponse.success(authService.reissue(refreshToken)));
     }
 
-    @Operation(summary = "로그아웃 (Refresh Token 삭제 + Access Token 블랙리스트 등록)")
+    @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
             Authentication authentication,
@@ -52,7 +52,7 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @Operation(summary = "내 정보 조회 (Access Token 검증)")
+    @Operation(summary = "내 정보 조회")
     @GetMapping("/me")
     public ResponseEntity<BaseResponse<UserResponse>> me(Authentication authentication) {
 

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -1,11 +1,14 @@
 package org.sopt.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.sopt.dto.response.BaseResponse;
 import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
 import org.sopt.service.AuthService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -35,6 +38,20 @@ public class AuthController {
         return ResponseEntity.ok(BaseResponse.success(authService.reissue(refreshToken)));
     }
 
+    @Operation(summary = "로그아웃 (Refresh Token 삭제 + Access Token 블랙리스트 등록)")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            Authentication authentication,
+            @Parameter(hidden = true)
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader
+    ) {
+        authService.logout(
+                Long.parseLong(authentication.getName()),
+                extractBearerToken(authorizationHeader)
+        );
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     @Operation(summary = "내 정보 조회 (Access Token 검증)")
     @GetMapping("/me")
     public ResponseEntity<BaseResponse<UserResponse>> me(Authentication authentication) {
@@ -47,5 +64,9 @@ public class AuthController {
         UserResponse user = authService.getUserById(memberId);
 
         return ResponseEntity.ok(BaseResponse.success(user));
+    }
+
+    private String extractBearerToken(String authorizationHeader) {
+        return authorizationHeader.substring("Bearer ".length()).trim();
     }
 }

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -1,6 +1,7 @@
 package org.sopt.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 import org.sopt.dto.response.BaseResponse;
 import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
@@ -11,13 +12,10 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
-
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
 
     @Operation(summary = "로그인 (Access Token + Refresh Token 발급)")
     @PostMapping("/login")

--- a/src/main/java/org/sopt/controller/LikeController.java
+++ b/src/main/java/org/sopt/controller/LikeController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Like", description = "좋아요 관련 API")
 @RestController
-@RequestMapping("/posts/{postId}/likes")
+@RequestMapping("/api/v1/posts/{postId}/likes")
 @RequiredArgsConstructor
 public class LikeController {
     private final LikeService likeService;

--- a/src/main/java/org/sopt/controller/LikeController.java
+++ b/src/main/java/org/sopt/controller/LikeController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.sopt.dto.response.BaseResponse;
 import org.sopt.dto.response.IdResponse;
 import org.sopt.service.LikeService;
@@ -17,12 +18,9 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Like", description = "좋아요 관련 API")
 @RestController
 @RequestMapping("/posts/{postId}/likes")
+@RequiredArgsConstructor
 public class LikeController {
     private final LikeService likeService;
-
-    public LikeController(LikeService likeService) {
-        this.likeService = likeService;
-    }
 
     @Operation(summary = "좋아요 추가", description = "게시글에 좋아요를 추가합니다.")
     @ApiResponses({

--- a/src/main/java/org/sopt/controller/LikeController.java
+++ b/src/main/java/org/sopt/controller/LikeController.java
@@ -6,12 +6,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.sopt.dto.request.LikeRequest;
 import org.sopt.dto.response.BaseResponse;
 import org.sopt.dto.response.IdResponse;
 import org.sopt.service.LikeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Like", description = "좋아요 관련 API")
@@ -34,10 +34,10 @@ public class LikeController {
     public ResponseEntity<BaseResponse<IdResponse>> addLike(
             @Parameter(description = "게시글 ID", required = true, example = "1")
             @PathVariable Long postId,
-            @RequestBody LikeRequest request
+            Authentication authentication
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(BaseResponse.success(likeService.addLike(postId, request.userId())));
+                .body(BaseResponse.success(likeService.addLike(postId, getAuthenticatedUserId(authentication))));
     }
 
     @Operation(summary = "좋아요 취소", description = "게시글에 누른 좋아요를 취소합니다.")
@@ -49,9 +49,13 @@ public class LikeController {
     public ResponseEntity<BaseResponse<Void>> cancelLike(
             @Parameter(description = "게시글 ID", required = true, example = "1")
             @PathVariable Long postId,
-            @RequestBody LikeRequest request
+            Authentication authentication
     ) {
-        likeService.cancelLike(postId, request.userId());
+        likeService.cancelLike(postId, getAuthenticatedUserId(authentication));
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    private Long getAuthenticatedUserId(Authentication authentication) {
+        return Long.parseLong(authentication.getName());
     }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.*;
@@ -18,12 +19,9 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Post", description = "게시글 관련 API")
 @RestController
 @RequestMapping("/posts")
+@RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
-
-    public PostController(PostService postService) {
-        this.postService = postService;
-    }
 
     @Operation(summary = "게시글 생성", description = "새 게시글을 생성합니다.")
     @ApiResponses({

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -96,9 +96,10 @@ public class PostController {
     public BaseResponse<IdResponse> updatePost(
             @Parameter(description = "게시글 ID", required = true, example = "1")
             @PathVariable Long id,
-            @RequestBody UpdatePostRequest request
+            @RequestBody UpdatePostRequest request,
+            Authentication authentication
     ) {
-        return BaseResponse.success(postService.updatePost(id, request));
+        return BaseResponse.success(postService.updatePost(id, request, getAuthenticatedUserId(authentication)));
     }
 
     @Operation(summary = "게시글 삭제", description = "게시글 ID로 특정 게시글을 삭제합니다.")
@@ -109,9 +110,10 @@ public class PostController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePost(
             @Parameter(description = "게시글 ID", required = true, example = "1")
-            @PathVariable Long id
+            @PathVariable Long id,
+            Authentication authentication
     ) {
-        postService.deletePost(id);
+        postService.deletePost(id, getAuthenticatedUserId(authentication));
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -12,6 +12,7 @@ import org.sopt.dto.response.*;
 import org.sopt.service.PostService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Post", description = "게시글 관련 API")
@@ -31,9 +32,10 @@ public class PostController {
     })
     @PostMapping
     public ResponseEntity<BaseResponse<IdResponse>> createPost(
-            @RequestBody CreatePostRequest request
+            @RequestBody CreatePostRequest request,
+            Authentication authentication
     ) {
-        IdResponse response = postService.createPost(request);
+        IdResponse response = postService.createPost(request, getAuthenticatedUserId(authentication));
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success(response));
     }
 
@@ -111,5 +113,9 @@ public class PostController {
     ) {
         postService.deletePost(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    private Long getAuthenticatedUserId(Authentication authentication) {
+        return Long.parseLong(authentication.getName());
     }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Post", description = "게시글 관련 API")
 @RestController
-@RequestMapping("/posts")
+@RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;

--- a/src/main/java/org/sopt/controller/UserController.java
+++ b/src/main/java/org/sopt/controller/UserController.java
@@ -10,7 +10,6 @@ import org.sopt.dto.request.CreateUserRequest;
 import org.sopt.dto.request.UpdateUserRequest;
 import org.sopt.dto.response.BaseResponse;
 import org.sopt.dto.response.IdResponse;
-import org.sopt.dto.response.UserResponse;
 import org.sopt.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -37,19 +36,6 @@ public class UserController {
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BaseResponse.success(userService.createUser(request)));
-    }
-
-    @Operation(summary = "사용자 조회", description = "사용자 ID로 사용자 정보를 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "사용자 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
-    })
-    @GetMapping("/{id}")
-    public BaseResponse<UserResponse> getUser(
-            @Parameter(description = "사용자 ID", required = true, example = "1")
-            @PathVariable Long id
-    ) {
-        return BaseResponse.success(userService.getUser(id));
     }
 
     @Operation(summary = "사용자 수정", description = "사용자 ID로 사용자 정보를 수정합니다.")

--- a/src/main/java/org/sopt/controller/UserController.java
+++ b/src/main/java/org/sopt/controller/UserController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.sopt.dto.request.CreateUserRequest;
 import org.sopt.dto.request.UpdateUserRequest;
 import org.sopt.dto.response.BaseResponse;
@@ -18,12 +19,9 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
 @RequestMapping("/users")
+@RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
-
-    public UserController(UserService userService) {
-        this.userService = userService;
-    }
 
     @Operation(summary = "사용자 생성", description = "새 사용자를 생성합니다.")
     @ApiResponses({

--- a/src/main/java/org/sopt/controller/UserController.java
+++ b/src/main/java/org/sopt/controller/UserController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;

--- a/src/main/java/org/sopt/controller/UserController.java
+++ b/src/main/java/org/sopt/controller/UserController.java
@@ -1,7 +1,6 @@
 package org.sopt.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -13,6 +12,7 @@ import org.sopt.dto.response.IdResponse;
 import org.sopt.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "사용자 관련 API")
@@ -38,32 +38,33 @@ public class UserController {
                 .body(BaseResponse.success(userService.createUser(request)));
     }
 
-    @Operation(summary = "사용자 수정", description = "사용자 ID로 사용자 정보를 수정합니다.")
+    @Operation(summary = "사용자 수정", description = "인증된 사용자의 비밀번호와 닉네임을 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "사용자 수정 성공"),
-            @ApiResponse(responseCode = "400", description = "유효성 검증 실패 (닉네임 누락)", content = @Content),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
     })
-    @PutMapping("/{id}")
+    @PatchMapping
     public BaseResponse<IdResponse> updateUser(
-            @Parameter(description = "사용자 ID", required = true, example = "1")
-            @PathVariable Long id,
-            @RequestBody UpdateUserRequest request
+            @RequestBody UpdateUserRequest request,
+            Authentication authentication
     ) {
-        return BaseResponse.success(userService.updateUser(id, request));
+        return BaseResponse.success(userService.updateUser(request, getAuthenticatedUserId(authentication)));
     }
 
-    @Operation(summary = "사용자 삭제", description = "사용자 ID로 해당 사용자를 삭제합니다.")
+    @Operation(summary = "사용자 삭제", description = "인증된 사용자를 삭제합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "사용자 삭제 성공"),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
     })
-    @DeleteMapping("/{id}")
+    @DeleteMapping
     public ResponseEntity<BaseResponse<Void>> deleteUser(
-            @Parameter(description = "사용자 ID", required = true, example = "1")
-            @PathVariable Long id
+            Authentication authentication
     ) {
-        userService.deleteUser(id);
+        userService.deleteUser(getAuthenticatedUserId(authentication));
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    private Long getAuthenticatedUserId(Authentication authentication) {
+        return Long.parseLong(authentication.getName());
     }
 }

--- a/src/main/java/org/sopt/domain/BlacklistedAccessToken.java
+++ b/src/main/java/org/sopt/domain/BlacklistedAccessToken.java
@@ -1,0 +1,31 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class BlacklistedAccessToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    protected BlacklistedAccessToken() {
+    }
+
+    private BlacklistedAccessToken(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public static BlacklistedAccessToken of(String token, LocalDateTime expiresAt) {
+        return new BlacklistedAccessToken(token, expiresAt);
+    }
+}

--- a/src/main/java/org/sopt/domain/RefreshToken.java
+++ b/src/main/java/org/sopt/domain/RefreshToken.java
@@ -42,4 +42,12 @@ public class RefreshToken {
         this.token = newToken;
         this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSeconds);
     }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public boolean isExpired() {
+        return expiresAt.isBefore(LocalDateTime.now());
+    }
 }

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -36,7 +36,12 @@ public class User extends BaseTimeEntity {
         return this.password;
     }
 
-    public void update(String nickname) {
-        this.nickname = nickname;
+    public void update(String password, String nickname) {
+        if (password != null) {
+            this.password = password;
+        }
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
     }
 }

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CreatePostRequest(
         @Schema(description = "게시글 제목 (최대 50자)", example = "안녕하세요") String title,
         @Schema(description = "게시글 내용", example = "첫 번째 게시글입니다.") String content,
-        @Schema(description = "작성자 사용자 ID", example = "1") Long userId,
         @Schema(description = "게시판 종류 (FREE, HOT, SECRET)", example = "FREE") String boardType
 ) {
 }

--- a/src/main/java/org/sopt/dto/request/LikeRequest.java
+++ b/src/main/java/org/sopt/dto/request/LikeRequest.java
@@ -1,9 +1,0 @@
-package org.sopt.dto.request;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-
-@Schema(description = "좋아요 요청")
-public record LikeRequest(
-        @Schema(description = "사용자 ID", example = "1") Long userId
-) {
-}

--- a/src/main/java/org/sopt/dto/request/UpdateUserRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdateUserRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "사용자 수정 요청")
 public record UpdateUserRequest(
+        @Schema(description = "수정할 비밀번호", example = "newPassword1234") String password,
         @Schema(description = "수정할 닉네임", example = "김철수") String nickname
 ) {
 }

--- a/src/main/java/org/sopt/exception/AuthErrorCode.java
+++ b/src/main/java/org/sopt/exception/AuthErrorCode.java
@@ -1,0 +1,23 @@
+package org.sopt.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements ErrorCode {
+    UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "UNAUTHENTICATED", "인증이 필요합니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "Refresh Token이 유효하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override public HttpStatus getHttpStatus() { return httpStatus; }
+    @Override public String getCode() { return code; }
+    @Override public String getMessage() { return message; }
+}

--- a/src/main/java/org/sopt/exception/AuthErrorCode.java
+++ b/src/main/java/org/sopt/exception/AuthErrorCode.java
@@ -5,6 +5,9 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
     UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "UNAUTHENTICATED", "인증이 필요합니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "TOKEN_REQUIRED", "토큰이 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "토큰이 유효하지 않습니다."),
+    INVALID_TOKEN_SUBJECT(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN_SUBJECT", "JWT의 사용자 정보가 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "Refresh Token이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/exception/PostErrorCode.java
+++ b/src/main/java/org/sopt/exception/PostErrorCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum PostErrorCode implements ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글이 존재하지 않습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_FORBIDDEN", "본인이 작성한 게시글만 수정하거나 삭제할 수 있습니다."),
     POST_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "POST_TITLE_REQUIRED", "제목은 필수입니다!"),
     POST_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "POST_TITLE_TOO_LONG", "제목은 50글자 이하로 작성해주세요!"),
     POST_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "POST_CONTENT_REQUIRED", "내용은 필수입니다!"),

--- a/src/main/java/org/sopt/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/exception/UserErrorCode.java
@@ -3,7 +3,8 @@ package org.sopt.exception;
 import org.springframework.http.HttpStatus;
 
 public enum UserErrorCode implements ErrorCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 ID의 User가 존재하지 않습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 ID의 User가 존재하지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMAIL_ALREADY_EXISTS", "이미 사용 중인 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/sopt/repository/BlacklistedAccessTokenRepository.java
+++ b/src/main/java/org/sopt/repository/BlacklistedAccessTokenRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.repository;
+
+import org.sopt.domain.BlacklistedAccessToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlacklistedAccessTokenRepository extends JpaRepository<BlacklistedAccessToken, Long> {
+    boolean existsByToken(String token);
+}

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.sopt.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.domain.RefreshToken;
 import org.sopt.domain.User;
 import org.sopt.dto.response.TokenResponse;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class AuthService {
 
     private final UserRepository userRepository;
@@ -24,18 +26,6 @@ public class AuthService {
 
     @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
     private long refreshTokenExpiresInSeconds;
-
-    public AuthService(
-            UserRepository userRepository,
-            RefreshTokenRepository refreshTokenRepository,
-            JwtService jwtService,
-            PasswordEncoder passwordEncoder
-    ) {
-        this.userRepository = userRepository;
-        this.refreshTokenRepository = refreshTokenRepository;
-        this.jwtService = jwtService;
-        this.passwordEncoder = passwordEncoder;
-    }
 
     public UserResponse loginWithCredentials(String email, String password) {
         User user = userRepository.findByEmail(email)

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -79,7 +79,7 @@ public class AuthService {
 
     private Long verifyRefreshToken(String refreshToken) {
         try {
-            return jwtService.verifyAndGetMemberId(refreshToken);
+            return jwtService.verifyAndGetUserId(refreshToken);
         } catch (IllegalArgumentException | JWTVerificationException e) {
             throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -1,9 +1,13 @@
 package org.sopt.service;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.sopt.domain.RefreshToken;
 import org.sopt.domain.User;
 import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.CustomException;
+import org.sopt.exception.UserErrorCode;
 import org.sopt.repository.RefreshTokenRepository;
 import org.sopt.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,10 +32,10 @@ public class AuthService {
 
     public UserResponse loginWithCredentials(String email, String password) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_CREDENTIALS));
 
         if (!user.getPassword().equals(password)) {
-            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+            throw new CustomException(AuthErrorCode.INVALID_CREDENTIALS);
         }
 
         return new UserResponse(user);
@@ -53,9 +57,37 @@ public class AuthService {
         return TokenResponse.of(accessToken, refreshToken);
     }
 
+    @Transactional
+    public TokenResponse reissue(String refreshToken) {
+        Long memberId = verifyRefreshToken(refreshToken);
+        RefreshToken savedRefreshToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        if (!savedRefreshToken.getMemberId().equals(memberId) || savedRefreshToken.isExpired()) {
+            throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        User user = userRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        String newAccessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+        String newRefreshToken = jwtService.generateRefreshToken(user.getId());
+        savedRefreshToken.rotate(newRefreshToken, refreshTokenExpiresInSeconds);
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+
+    private Long verifyRefreshToken(String refreshToken) {
+        try {
+            return jwtService.verifyAndGetMemberId(refreshToken);
+        } catch (IllegalArgumentException | JWTVerificationException e) {
+            throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
     public UserResponse getUserById(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         return new UserResponse(user);
     }
 }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -1,6 +1,7 @@
 package org.sopt.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.domain.BlacklistedAccessToken;
 import org.sopt.domain.RefreshToken;
 import org.sopt.domain.User;
 import org.sopt.dto.response.TokenResponse;
@@ -8,6 +9,7 @@ import org.sopt.dto.response.UserResponse;
 import org.sopt.exception.AuthErrorCode;
 import org.sopt.exception.CustomException;
 import org.sopt.exception.UserErrorCode;
+import org.sopt.repository.BlacklistedAccessTokenRepository;
 import org.sopt.repository.RefreshTokenRepository;
 import org.sopt.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +23,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistedAccessTokenRepository blacklistedAccessTokenRepository;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
 
@@ -45,7 +48,6 @@ public class AuthService {
         String accessToken = jwtService.generateAccessToken(member.id(), member.email());
         String refreshToken = jwtService.generateRefreshToken(member.id());
 
-        // 기존 Refresh Token 삭제 후 새로 저장
         refreshTokenRepository.deleteByMemberId(member.id());
         refreshTokenRepository.save(
                 RefreshToken.of(member.id(), refreshToken, refreshTokenExpiresInSeconds)
@@ -72,6 +74,17 @@ public class AuthService {
         savedRefreshToken.rotate(newRefreshToken, refreshTokenExpiresInSeconds);
 
         return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void logout(Long userId, String accessToken) {
+        refreshTokenRepository.deleteByMemberId(userId);
+
+        if (!blacklistedAccessTokenRepository.existsByToken(accessToken)) {
+            blacklistedAccessTokenRepository.save(
+                    BlacklistedAccessToken.of(accessToken, jwtService.getExpiresAt(accessToken))
+            );
+        }
     }
 
     private Long verifyRefreshToken(String refreshToken) {

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -1,6 +1,5 @@
 package org.sopt.service;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.sopt.domain.RefreshToken;
 import org.sopt.domain.User;
 import org.sopt.dto.response.TokenResponse;
@@ -80,7 +79,7 @@ public class AuthService {
     private Long verifyRefreshToken(String refreshToken) {
         try {
             return jwtService.verifyAndGetUserId(refreshToken);
-        } catch (IllegalArgumentException | JWTVerificationException e) {
+        } catch (CustomException e) {
             throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
     }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -10,6 +10,7 @@ import org.sopt.exception.UserErrorCode;
 import org.sopt.repository.RefreshTokenRepository;
 import org.sopt.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,21 +20,28 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
     private long refreshTokenExpiresInSeconds;
 
-    public AuthService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository, JwtService jwtService) {
+    public AuthService(
+            UserRepository userRepository,
+            RefreshTokenRepository refreshTokenRepository,
+            JwtService jwtService,
+            PasswordEncoder passwordEncoder
+    ) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtService = jwtService;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public UserResponse loginWithCredentials(String email, String password) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_CREDENTIALS));
 
-        if (!user.getPassword().equals(password)) {
+        if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new CustomException(AuthErrorCode.INVALID_CREDENTIALS);
         }
 

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -15,19 +15,14 @@ import java.util.Date;
 @Service
 public class JwtService {
 
-    private final Algorithm algorithm;
-    private final long accessTokenExpiresInSeconds;
-    private final long refreshTokenExpiresInSeconds;
+    @Value("${security.jwt.secret}")
+    private String secret;
 
-    public JwtService(
-            @Value("${security.jwt.secret}") String secret,
-            @Value("${security.jwt.access-token-expires-in-seconds:1800}") long accessTokenExpiresInSeconds,
-            @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}") long refreshTokenExpiresInSeconds
-    ) {
-        this.algorithm = Algorithm.HMAC256(secret);
-        this.accessTokenExpiresInSeconds = accessTokenExpiresInSeconds;
-        this.refreshTokenExpiresInSeconds = refreshTokenExpiresInSeconds;
-    }
+    @Value("${security.jwt.access-token-expires-in-seconds:1800}")
+    private long accessTokenExpiresInSeconds;
+
+    @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
+    private long refreshTokenExpiresInSeconds;
 
     public String generateAccessToken(Long userId, String email) {
         Instant now = Instant.now();
@@ -36,7 +31,7 @@ public class JwtService {
                 .withClaim("email", email)
                 .withIssuedAt(Date.from(now))
                 .withExpiresAt(Date.from(now.plusSeconds(accessTokenExpiresInSeconds)))
-                .sign(algorithm);
+                .sign(getAlgorithm());
     }
 
     public String generateRefreshToken(Long userId) {
@@ -45,7 +40,7 @@ public class JwtService {
                 .withSubject(String.valueOf(userId))
                 .withIssuedAt(Date.from(now))
                 .withExpiresAt(Date.from(now.plusSeconds(refreshTokenExpiresInSeconds)))
-                .sign(algorithm);
+                .sign(getAlgorithm());
     }
 
     public Long verifyAndGetUserId(String token) {
@@ -55,7 +50,7 @@ public class JwtService {
 
         DecodedJWT jwt;
         try {
-            jwt = JWT.require(algorithm).build().verify(token);
+            jwt = JWT.require(getAlgorithm()).build().verify(token);
         } catch (JWTVerificationException e) {
             throw new CustomException(AuthErrorCode.INVALID_TOKEN);
         }
@@ -65,5 +60,9 @@ public class JwtService {
         } catch (NumberFormatException e) {
             throw new CustomException(AuthErrorCode.INVALID_TOKEN_SUBJECT);
         }
+    }
+
+    private Algorithm getAlgorithm() {
+        return Algorithm.HMAC256(secret);
     }
 }

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 @Service
@@ -60,6 +62,17 @@ public class JwtService {
         } catch (NumberFormatException e) {
             throw new CustomException(AuthErrorCode.INVALID_TOKEN_SUBJECT);
         }
+    }
+
+    public LocalDateTime getExpiresAt(String token) {
+        DecodedJWT jwt;
+        try {
+            jwt = JWT.require(getAlgorithm()).build().verify(token);
+        } catch (JWTVerificationException e) {
+            throw new CustomException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        return LocalDateTime.ofInstant(jwt.getExpiresAt().toInstant(), ZoneId.systemDefault());
     }
 
     private Algorithm getAlgorithm() {

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -2,7 +2,10 @@ package org.sopt.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import org.sopt.exception.AuthErrorCode;
+import org.sopt.exception.CustomException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -47,13 +50,20 @@ public class JwtService {
 
     public Long verifyAndGetUserId(String token) {
         if (token == null || token.isBlank()) {
-            throw new IllegalArgumentException("토큰이 없습니다.");
+            throw new CustomException(AuthErrorCode.TOKEN_REQUIRED);
         }
-        DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+
+        DecodedJWT jwt;
+        try {
+            jwt = JWT.require(algorithm).build().verify(token);
+        } catch (JWTVerificationException e) {
+            throw new CustomException(AuthErrorCode.INVALID_TOKEN);
+        }
+
         try {
             return Long.parseLong(jwt.getSubject());
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
+            throw new CustomException(AuthErrorCode.INVALID_TOKEN_SUBJECT);
         }
     }
 }

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -26,26 +26,26 @@ public class JwtService {
         this.refreshTokenExpiresInSeconds = refreshTokenExpiresInSeconds;
     }
 
-    public String generateAccessToken(Long memberId, String email) {
+    public String generateAccessToken(Long userId, String email) {
         Instant now = Instant.now();
         return JWT.create()
-                .withSubject(String.valueOf(memberId))
+                .withSubject(String.valueOf(userId))
                 .withClaim("email", email)
                 .withIssuedAt(Date.from(now))
                 .withExpiresAt(Date.from(now.plusSeconds(accessTokenExpiresInSeconds)))
                 .sign(algorithm);
     }
 
-    public String generateRefreshToken(Long memberId) {
+    public String generateRefreshToken(Long userId) {
         Instant now = Instant.now();
         return JWT.create()
-                .withSubject(String.valueOf(memberId))
+                .withSubject(String.valueOf(userId))
                 .withIssuedAt(Date.from(now))
                 .withExpiresAt(Date.from(now.plusSeconds(refreshTokenExpiresInSeconds)))
                 .sign(algorithm);
     }
 
-    public Long verifyAndGetMemberId(String token) {
+    public Long verifyAndGetUserId(String token) {
         if (token == null || token.isBlank()) {
             throw new IllegalArgumentException("토큰이 없습니다.");
         }

--- a/src/main/java/org/sopt/service/LikeService.java
+++ b/src/main/java/org/sopt/service/LikeService.java
@@ -1,5 +1,6 @@
 package org.sopt.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.domain.Like;
 import org.sopt.domain.Post;
 import org.sopt.domain.User;
@@ -20,20 +21,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class LikeService {
     private final LikeRepository likeRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
-
-    public LikeService(
-            LikeRepository likeRepository,
-            PostRepository postRepository,
-            UserRepository userRepository
-    ) {
-        this.likeRepository = likeRepository;
-        this.postRepository = postRepository;
-        this.userRepository = userRepository;
-    }
 
     @Retryable(
             retryFor = DataIntegrityViolationException.class,

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -1,5 +1,6 @@
 package org.sopt.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.domain.BoardType;
 import org.sopt.domain.Post;
 import org.sopt.domain.User;
@@ -23,17 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
-
-    public PostService(
-            PostRepository postRepository,
-            UserRepository userRepository
-    ) {
-        this.postRepository = postRepository;
-        this.userRepository = userRepository;
-    }
 
     @Transactional
     public IdResponse createPost(CreatePostRequest request, Long userId) {

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -36,10 +36,10 @@ public class PostService {
     }
 
     @Transactional
-    public IdResponse createPost(CreatePostRequest request) {
+    public IdResponse createPost(CreatePostRequest request, Long userId) {
         PostValidator.validateCreatePost(request);
 
-        User user = userRepository.findById(request.userId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         Post post = postRepository.save(new Post(

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -74,19 +74,27 @@ public class PostService {
     }
 
     @Transactional
-    public IdResponse updatePost(Long id, UpdatePostRequest request) {
+    public IdResponse updatePost(Long id, UpdatePostRequest request, Long userId) {
         PostValidator.validateUpdatePost(request);
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+        validatePostOwner(post, userId);
         post.update(request.title(), request.content());
         return new IdResponse(post.getId());
     }
 
     @Transactional
-    public void deletePost(Long id) {
+    public void deletePost(Long id, Long userId) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+        validatePostOwner(post, userId);
         post.softDelete();
+    }
+
+    private void validatePostOwner(Post post, Long userId) {
+        if (!post.getUser().getId().equals(userId)) {
+            throw new CustomException(PostErrorCode.POST_FORBIDDEN);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -1,10 +1,10 @@
 package org.sopt.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.domain.User;
 import org.sopt.dto.request.CreateUserRequest;
 import org.sopt.dto.request.UpdateUserRequest;
 import org.sopt.dto.response.IdResponse;
-import org.sopt.dto.response.UserResponse;
 import org.sopt.exception.CustomException;
 import org.sopt.exception.UserErrorCode;
 import org.sopt.repository.UserRepository;
@@ -13,14 +13,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-
-    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
-        this.userRepository = userRepository;
-        this.passwordEncoder = passwordEncoder;
-    }
 
     @Transactional
     public IdResponse createUser(CreateUserRequest request) {

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -8,15 +8,18 @@ import org.sopt.dto.response.UserResponse;
 import org.sopt.exception.CustomException;
 import org.sopt.exception.UserErrorCode;
 import org.sopt.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public UserService(UserRepository userRepository) {
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Transactional
@@ -25,7 +28,11 @@ public class UserService {
             throw new CustomException(UserErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
-        User user = userRepository.save(new User(request.password(), request.nickname(), request.email()));
+        User user = userRepository.save(new User(
+                passwordEncoder.encode(request.password()),
+                request.nickname(),
+                request.email()
+        ));
         return new IdResponse(user.getId());
     }
 
@@ -33,8 +40,15 @@ public class UserService {
     public IdResponse updateUser(UpdateUserRequest request, Long authenticatedUserId) {
         User user = userRepository.findById(authenticatedUserId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-        user.update(request.password(), request.nickname());
+        user.update(encodePasswordIfPresent(request.password()), request.nickname());
         return new IdResponse(user.getId());
+    }
+
+    private String encodePasswordIfPresent(String password) {
+        if (password == null) {
+            return null;
+        }
+        return passwordEncoder.encode(password);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -25,13 +25,6 @@ public class UserService {
         return new IdResponse(user.getId());
     }
 
-    @Transactional(readOnly = true)
-    public UserResponse getUser(Long id) {
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-        return new UserResponse(user);
-    }
-
     @Transactional
     public IdResponse updateUser(Long id, UpdateUserRequest request) {
         User user = userRepository.findById(id)

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -21,6 +21,10 @@ public class UserService {
 
     @Transactional
     public IdResponse createUser(CreateUserRequest request) {
+        if (userRepository.findByEmail(request.email()).isPresent()) {
+            throw new CustomException(UserErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
         User user = userRepository.save(new User(request.password(), request.nickname(), request.email()));
         return new IdResponse(user.getId());
     }

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -26,16 +26,16 @@ public class UserService {
     }
 
     @Transactional
-    public IdResponse updateUser(Long id, UpdateUserRequest request) {
-        User user = userRepository.findById(id)
+    public IdResponse updateUser(UpdateUserRequest request, Long authenticatedUserId) {
+        User user = userRepository.findById(authenticatedUserId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-        user.update(request.nickname());
+        user.update(request.password(), request.nickname());
         return new IdResponse(user.getId());
     }
 
     @Transactional
-    public void deleteUser(Long id) {
-        User user = userRepository.findById(id)
+    public void deleteUser(Long authenticatedUserId) {
+        User user = userRepository.findById(authenticatedUserId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         userRepository.delete(user);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,6 @@ spring:
 
 security:
   jwt:
-    secret: ${JWT_SECRETE}
+    secret: ${JWT_SECRET}
     access-token-expires-in-seconds: 1800     # 30분
     refresh-token-expires-in-seconds: 1209600 # 2주


### PR DESCRIPTION
# 🔥*Pull requests*
- Resolved: #16

## 👷 **과제 구현**

### 필수과제
- [x] JWT + Spring Security 인증 적용하기. 로그인/토큰 재발급 API는 인증 없이 접근 가능하고, 게시글 작성/수정/삭제, 좋아요 추가/취소는 인증이 필요하도록 설정하기.
- [x] `BCryptPasswordEncoder`를 사용해서 비밀번호를 암호화해서 저장하고, 로그인 시 `matches()`로 검증하도록 수정하기

<br>

### 선택과제
- [x] 로그아웃 API를 구현하기. 로그아웃 시 DB에서 해당 유저의 Refresh Token을 삭제하고, 현재 Access Token을 블랙리스트에 추가해서 만료 전에도 사용할 수 없도록 하기. Access Token이 만료됐을 때 클라이언트가 어떻게 401을 감지해서 로그인 페이지로 이동시킬지 흐름도 함께 작성하기.
- [ ] Kakao 또는 Google OAuth 2.0 소셜 로그인을 구현하기. 외부 인증 서버로부터 유저 정보를 받아온 후, 우리 서버에서 JWT(Access Token + Refresh Token)를 발급하는 흐름까지 완성하기. 신규 유저라면 자동으로 회원가입 처리하고, 기존 유저라면 로그인 처리하기.

<br>

### **구현한 내용에 대해서 설명해주세요**

- JWT 기반 인증/인가 기능을 프로젝트 전반에 적용했습니다.
    - Spring Security와 JWT 인증 필터를 추가해 Authorization: Bearer {accessToken} 방식으로 인증을 처리하도록 구현했습니다.
    - 로그인 API에서 Access Token과 Refresh Token을 발급하고, Refresh Token은 DB에 저장하도록 구현했습니다.
    - 토큰 재발급 API를 구현해 유효한 Refresh Token으로 새로운 Access Token과 Refresh Token을 발급받을 수 있도록 했습니다.
    - 로그아웃 API를 구현했습니다.
        - 로그아웃 시 DB에 저장된 해당 사용자의 Refresh Token을 삭제합니다.
        - 현재 사용 중인 Access Token은 블랙리스트 테이블에 저장해 만료 전에도 사용할 수 없도록 처리했습니다.
    - Swagger에서 Bearer JWT 인증을 사용할 수 있도록 보안 스키마를 추가했습니다.

- 사용자 관련 기능도 인증 흐름에 맞게 수정했습니다.
    - 사용자 생성 API는 인증 없이 접근 가능하도록 열었습니다.
    - 사용자 생성 시 기존 사용자와 동일한 email을 사용할 수 없도록 중복 검증을 추가했습니다.
    - 비밀번호는 BCryptPasswordEncoder를 사용해 암호화하여 저장하도록 변경했습니다.
    - 로그인 시 평문 비밀번호 비교 대신 passwordEncoder.matches()로 검증하도록 수정했습니다.
    - 사용자 조회 API인 GET /users/{id}를 제거했습니다.
    - 사용자 수정 API를 PATCH /api/v1/users로 변경했습니다.
    - 사용자 수정/삭제 시 path variable로 id를 받지 않고, JWT 인증 정보에서 사용자 ID를 가져와 본인 계정만 수정/삭제되도록 했습니다.

- 게시글과 좋아요 기능도 인증 사용자 기준으로 변경했습니다.
    - 게시글 작성/수정/삭제는 인증이 필요하도록 설정했습니다.
    - 게시글 전체 조회, 단건 조회, 검색은 인증 없이 접근 가능하도록 설정했습니다.
    - 게시글 작성 시 request body에서 userId를 받지 않고, JWT 인증 정보의 사용자 ID를 사용하도록 변경했습니다.
    - 게시글 수정/삭제 시 본인이 작성한 게시글만 수정/삭제할 수 있도록 검증 로직을 추가했습니다.
    - 좋아요 추가/취소도 request body의 userId 대신 JWT 인증 정보의 사용자 ID를 사용하도록 변경했습니다.


<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

- 사용자 수정 API는 전체 교체에 가까운 PUT보다 일부 필드만 수정하는 의미의 PATCH가 더 적절하다고 판단해 PATCH /api/v1/users로 변경했습니다. 또한 비밀번호나 닉네임 중 일부만 보낼 수 있도록 하고, 요청에 포함되지 않은 필드는 기존 값을 유지하도록 처리했습니다.
- API 인증 범위도 고민했습니다. 기본적으로는 인증이 필요 없는 URL만 명시적으로 열고, 나머지는 모두 인증이 필요하도록 구성했습니다. 그 위에서 회원가입, 로그인, 토큰 재발급, 게시글 조회 API처럼 공개되어야 하는 API만 예외로 두었습니다. 이렇게 하면 새 API가 추가되더라도 기본적으로 보호되어 실수로 인증이 빠지는 상황을 줄일 수 있다고 생각했습니다.

<br>

---
### **키워드 과제 정리내용**

<details>
<summary>OAuth 2.0란?</summary>
<div>
<br>

OAuth 2.0은 사용자가 자신의 아이디와 비밀번호를 직접 넘기지 않고, 특정 애플리케이션이 사용자의 리소스에 제한적으로 접근할 수 있도록 허용하는 인가(Authorization) 프레임워크이다.

예를 들어 어떤 서비스가 사용자의 구글 캘린더, 카카오 프로필, 네이버 이메일 정보 등에 접근해야 할 때, 사용자는 자신의 비밀번호를 해당 서비스에 제공하지 않는다. 대신 OAuth 제공자가 발급한 Access Token을 통해 필요한 범위의 리소스에만 접근하도록 허용한다.

### 1. 인증과 인가 차이

인증(Authentication)은 누구인지를 확인하는 과정이다.
인가(Authorization)는 사용자가 해당 자원에 접근 가능한지를 확인하는 과정이다.

### 2. OAuth 2.0이 필요한 이유

OAuth 2.0이 없다면, 어떤 애플리케이션이 사용자의 외부 서비스 정보를 가져오기 위해 사용자의 아이디와 비밀번호를 직접 입력받아야 할 수 있다.

하지만 이 방식은 사용자의 비밀번호가 외부 애플리케이션에 노출될 수 있고, 애플리케이션이 사용자 계정 전체에 접근할 가능성도 생기기 때문에 위험하다.

OAuth 2.0에서는 사용자의 비밀번호를 애플리케이션에 전달하지 않는다.
대신 사용자가 허용한 범위에 대해서만 접근 가능한 Access Token을 발급한다.

즉, 애플리케이션은 사용자의 비밀번호를 알지 못하고, 발급받은 토큰을 사용해 허용된 리소스에만 접근한다.

### 3. OAuth 2.0 인가 흐름

가장 대표적인 방식은 Authorization Code Grant 방식이다.


```
사용자
→ Client에서 외부 서비스 로그인/연동 요청
→ Authorization Server로 이동
→ 사용자가 로그인하고 권한 동의
→ Authorization Server가 Authorization Code 발급
→ Client가 Authorization Code로 Access Token 요청
→ Authorization Server가 Access Token 발급
→ Client가 Access Token으로 Resource Server에 요청
→ Resource Server가 사용자 리소스 반환
```

사용자가 내가 만든 서비스에서 외부 서비스 로그인을 누르거나, 외부 서비스 연동을 요청하면 사용자를 Authorization Server의 인증/동의 페이지로 이동시킨다.

사용자는 Authorization Server에서 로그인한 후, Client가 요청한 권한 범위에 동의한다.
이 권한 범위를 Scope라고 한다.
예를 들면 프로필 정보 조회, 이메일 조회 등이 있을 수 있다.
Scope는 Client가 아무 리소스나 마음대로 접근하지 못하도록 제한하는 역할을 한다.

사용자가 로그인과 권한 동의를 완료하면 Authorization Server는 Client가 등록해둔 redirect_uri로 사용자를 다시 보낸다.
이때 URL에 code가 포함된다.
```
https://our-service.com/oauth/callback?code=abc123
```
여기서 code는 Authorization Code로, Access Token이 아니라 Access Token을 발급받기 위한 임시 코드다.

우리 서버는 받은 Authorization Code를 Authorization Server에 전달한다.
Authorization Server는 Authorization Code, Client ID, Redirect URI 등의 값이 유효한지 확인한 후, 유효하다면 Access Token을 발급한다.

이후 우리 서버는 Access Token을 사용해서 Resource Server에 사용자 리소스를 요청한다.
Resource Server는 Access Token이 유효한지 확인한 뒤, 요청한 리소스를 반환한다.

소셜 로그인에 사용하는 경우에는 반환된 사용자 정보를 바탕으로 서버 내부에서 회원가입 또는 로그인 처리를 하고, 우리 서비스 JWT를 발급할 수 있다.

</div>
</details>


<br>

---

## 🚨 참고 사항
